### PR TITLE
Fix README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ int main() {
   sha1_file("path/to/example.file", file_hash);
   
   // To hash a buffer
-  SHA1BuifferFunc sha1_buffer = (SHA1BufferFunc)GetProcAddress(hDll, "sha1_buffer");
+  SHA1BufferFunc sha1_buffer = (SHA1BufferFunc)GetProcAddress(hDll, "sha1_buffer");
   unsigned char buffer_hash[SHA1_BLOCK_SIZE];
   unsigned char *buffer;
   size_t buffer_size;


### PR DESCRIPTION
## Summary
- fix typo in README usage example

## Testing
- `gcc -shared -o sha1.dll sha1.c` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f86b3bbc083318291d412d0403349