### PR TITLE
Add SHA1 buffer test

### DIFF
--- a/sha1.c
+++ b/sha1.c
@@ -2,7 +2,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#if defined(_WIN32)
 #include <windows.h>
+#define DLL_EXPORT __declspec(dllexport)
+#else
+#define DLL_EXPORT
+#endif
 
 // SHA1 20-byte hash
 #define SHA1_BLOCK_SIZE 20
@@ -13,8 +18,8 @@ typedef struct {
     unsigned char buffer[64];
 } SHA1_CTX;
 
-__declspec(dllexport) void sha1_file(const char *filename, unsigned char output[SHA1_BLOCK_SIZE]);
-__declspec(dllexport) void sha1_buffer(const unsigned char *buffer, const size_t buffer_size, unsigned char output[SHA1_BLOCK_SIZE]);
+DLL_EXPORT void sha1_file(const char *filename, unsigned char output[SHA1_BLOCK_SIZE]);
+DLL_EXPORT void sha1_buffer(const unsigned char *buffer, const size_t buffer_size, unsigned char output[SHA1_BLOCK_SIZE]);
 
 #define ROL(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
 

--- a/tests/test_sha1.c
+++ b/tests/test_sha1.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define SHA1_BLOCK_SIZE 20
+
+/* Function implemented in sha1.c */
+void sha1_buffer(const unsigned char *buffer, const size_t buffer_size, unsigned char output[SHA1_BLOCK_SIZE]);
+
+int main(void) {
+    const char *input = "abc";
+    unsigned char hash[SHA1_BLOCK_SIZE];
+
+    sha1_buffer((const unsigned char *)input, strlen(input), hash);
+
+    const char *expected = "a9993e364706816aba3e25717850c26c9cd0d89d";
+    char result[SHA1_BLOCK_SIZE * 2 + 1];
+    for (int i = 0; i < SHA1_BLOCK_SIZE; i++) {
+        sprintf(result + i * 2, "%02x", hash[i]);
+    }
+    result[SHA1_BLOCK_SIZE * 2] = '\0';
+
+    if (strcmp(result, expected) != 0) {
+        fprintf(stderr, "Test failed\nExpected: %s\nGot: %s\n", expected, result);
+        return 1;
+    }
+
+    printf("Test passed\n");
+    return 0;
+}
+
+/*
+Compile and run the test with:
+    gcc -o test_sha1 tests/test_sha1.c sha1.c && ./test_sha1
+*/


### PR DESCRIPTION
## Summary
- make `sha1.c` build on non-Windows by defining `DLL_EXPORT`
- add `tests/test_sha1.c` with a small test verifying hashing of "abc"

## Testing
- `gcc -o test_sha1 tests/test_sha1.c sha1.c && ./test_sha1`

------
https://chatgpt.com/codex/tasks/task_e_683f87b60a30833190840a56a9ea9db1